### PR TITLE
[SQL] run sql in the tables with jinja {{}} errors

### DIFF
--- a/superset/models.py
+++ b/superset/models.py
@@ -1155,6 +1155,9 @@ class SqlaTable(Model, Queryable, AuditMixinNullable, ImportMixin):
             qry.compile(
                 engine, compile_kwargs={"literal_binds": True},),
         )
+        template_processor = get_template_processor(
+            database=self.database)
+        sql = template_processor.process_template(sql)
         df = pd.read_sql_query(
             sql=sql,
             con=engine


### PR DESCRIPTION
I update the models.py code to support the jinja in SQL of tables.

![11 7jfyq5k 0v5wf ttkkh9](https://cloud.githubusercontent.com/assets/19347709/20744423/eb071b50-b716-11e6-9819-4237e0de4036.jpg)

![y4lmxyc5d 5be97 tw gy_h](https://cloud.githubusercontent.com/assets/19347709/20744424/ec26abc2-b716-11e6-9db0-36a7357c9c15.jpg)

